### PR TITLE
TRIVY - Correcciones vulnerabilidades detectadas en el código de terraform

### DIFF
--- a/terraform/eks/main.tf
+++ b/terraform/eks/main.tf
@@ -80,6 +80,7 @@ resource "aws_iam_role_policy_attachment" "cluster" {
 
 # Recurso para crear EKS clúster
 # Documentación https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_cluster
+#trivy:ignore:AVD-AWS-0040
 resource "aws_eks_cluster" "this" {
   name                      = local.cluster_name
   role_arn                  = aws_iam_role.cluster.arn

--- a/terraform/falco/main.tf
+++ b/terraform/falco/main.tf
@@ -37,10 +37,9 @@ data "aws_iam_policy_document" "cloudwatch" {
   statement {
     sid = "ReadAccessToCloudWatchLogs"
     actions = [
-      "logs:Describe*",
-      "logs:FilterLogEvents",
-      "logs:Get*",
-      "logs:List*"
+      "logs:DescribeLogStreams",
+      "logs:GetLogEvents",
+      "logs:FilterLogEvents"
     ]
     effect = "Allow"
     resources = [

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -13,10 +13,11 @@ module "vpc" {
   resources_name = local.resources_name
 
   # Direccionamiento IP elegido para el VPC
-  vpc_cidr             = "172.16.0.0/20"
-  enable_dns_support   = true
-  enable_dns_hostnames = true
-  create_nat_gateway   = true
+  vpc_cidr              = "172.16.0.0/20"
+  enable_dns_support    = true
+  enable_dns_hostnames  = true
+  create_nat_gateway    = true
+  enable_vpc_flow_flogs = true
 
   # Distribución de las subredes públicas dentro del VPC
   public_subnets = {
@@ -61,7 +62,7 @@ module "eks" {
   source         = "./eks"
   resources_name = local.resources_name
 
-  cluster_enabled_log_types = ["api", "audit", "authenticator"]
+  cluster_enabled_log_types = ["api", "audit", "authenticator", "scheduler", "controllerManager"]
   # Versión del clúster EKS https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
   cluster_version = "1.29"
   # El control plane se desplegará en todas las subredes (privadas y públicas) y el endpoint será accesible internamente y públicamente
@@ -103,9 +104,10 @@ output "eks_cluster_name" {
 
 # Módulo para crear un repositorio ECR donde almacenar imágenes de contenedores en AWS
 module "ecr" {
-  source          = "./ecr"
-  repository_name = "debug-tools"
-  force_delete    = true
+  source               = "./ecr"
+  repository_name      = "debug-tools"
+  force_delete         = true
+  image_tag_mutability = "IMMUTABLE"
 
   depends_on = [module.eks]
 }

--- a/terraform/vpc/vars.tf
+++ b/terraform/vpc/vars.tf
@@ -34,3 +34,21 @@ variable "enable_dns_support" {
   type        = bool
   default     = null
 }
+
+variable "enable_vpc_flow_flogs" {
+  description = "Variable de tipo booleana para elegir si activar o no VPC Flow Logs"
+  type        = bool
+  default     = false
+}
+
+variable "vpc_flow_logs_cloudwatch_retention_in_days" {
+  description = "Número de días de retención en CloudWatch de VPC Flow Logs"
+  type        = number
+  default     = 7
+}
+
+variable "vpc_flow_logs_cloudwatch_skip_destroy" {
+  description = "Variable de tipo booleana para decidir si preservar los logs incluso si se se eliminar el recurso con terraform"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Pull Request para corregir las vulnerabilidades detectadas por Trivy en el código de terraform de este repositorio.

Salida del comando `trivy conf --severity="MEDIUM,HIGH,CRITICAL" --misconfig-scanners=terraform ./terraform`:

```
ecr/main.tf (terraform)

Tests: 2 (SUCCESSES: 1, FAILURES: 1, EXCEPTIONS: 0)
Failures: 1 (MEDIUM: 0, HIGH: 1, CRITICAL: 0)

HIGH: Repository tags are mutable.
═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
ECR images should be set to IMMUTABLE to prevent code injection through image mutation.

This can be done by setting <code>image_tab_mutability</code> to <code>IMMUTABLE</code>

See https://avd.aquasec.com/misconfig/avd-aws-0031
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 ecr/main.tf:4
   via ecr/main.tf:2-10 (aws_ecr_repository.this)
    via main.tf:105-111 (module.ecr)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   2   resource "aws_ecr_repository" "this" {
   3     name                 = var.repository_name
   4 [   image_tag_mutability = var.image_tag_mutability
   5     force_delete         = var.force_delete
   6
   7     image_scanning_configuration {
   8       scan_on_push = var.image_scanning_on_push
   9     }
  10   }
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────



eks/main.tf (terraform)

Tests: 10 (SUCCESSES: 7, FAILURES: 3, EXCEPTIONS: 0)
Failures: 3 (MEDIUM: 2, HIGH: 0, CRITICAL: 1)

MEDIUM: Control plane controller manager logging is not enabled.
═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
By default cluster control plane logging is not turned on. Logging is available for audit, api, authenticator, controllerManager and scheduler. All logging should be turned on for cluster control plane.

See https://avd.aquasec.com/misconfig/avd-aws-0038
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 eks/main.tf:83-121
   via main.tf:60-98 (module.eks)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  83 ┌ resource "aws_eks_cluster" "this" {
  84 │   name                      = local.cluster_name
  85 │   role_arn                  = aws_iam_role.cluster.arn
  86 │   version                   = var.cluster_version
  87 │   enabled_cluster_log_types = var.cluster_enabled_log_types
  88 │
  89 │   # Configuración de red proporcionada por las variables de entradas definidas en el archivo vars.tf
  90 │   vpc_config {
  91 └     subnet_ids              = var.cluster_subnets_ids
  ..
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────


MEDIUM: Control plane scheduler logging is not enabled.
═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
By default cluster control plane logging is not turned on. Logging is available for audit, api, authenticator, controllerManager and scheduler. All logging should be turned on for cluster control plane.

See https://avd.aquasec.com/misconfig/avd-aws-0038
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 eks/main.tf:83-121
   via main.tf:60-98 (module.eks)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  83 ┌ resource "aws_eks_cluster" "this" {
  84 │   name                      = local.cluster_name
  85 │   role_arn                  = aws_iam_role.cluster.arn
  86 │   version                   = var.cluster_version
  87 │   enabled_cluster_log_types = var.cluster_enabled_log_types
  88 │
  89 │   # Configuración de red proporcionada por las variables de entradas definidas en el archivo vars.tf
  90 │   vpc_config {
  91 └     subnet_ids              = var.cluster_subnets_ids
  ..
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────


CRITICAL: Public cluster access is enabled.
═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
EKS clusters are available publicly by default, this should be explicitly disabled in the vpc_config of the EKS cluster resource.

See https://avd.aquasec.com/misconfig/avd-aws-0040
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 eks/main.tf:93
   via eks/main.tf:90-96 (vpc_config)
    via eks/main.tf:83-121 (aws_eks_cluster.this)
     via main.tf:60-98 (module.eks)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  83   resource "aws_eks_cluster" "this" {
  ..
  93 [     endpoint_public_access  = var.cluster_endpoint_public_access
 ...
 121   }
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────



falco/main.tf (terraform)

Tests: 2 (SUCCESSES: 1, FAILURES: 1, EXCEPTIONS: 0)
Failures: 1 (MEDIUM: 0, HIGH: 1, CRITICAL: 0)

HIGH: IAM policy document uses wildcarded action 'logs:Describe*'
═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
You should use the principle of least privilege when defining your IAM policies. This means you should specify each exact permission required without using wildcards, as this could cause the granting of access to certain undesired actions, resources and principals.

See https://avd.aquasec.com/misconfig/avd-aws-0057
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 falco/main.tf:39-44
   via falco/main.tf:37-49 (data.aws_iam_policy_document.cloudwatch)
    via falco/main.tf:36-50 (data.aws_iam_policy_document.cloudwatch)
     via main.tf:134-144 (module.falco)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  36   data "aws_iam_policy_document" "cloudwatch" {
  37     statement {
  38       sid = "ReadAccessToCloudWatchLogs"
  39 ┌     actions = [
  40 │       "logs:Describe*",
  41 │       "logs:FilterLogEvents",
  42 │       "logs:Get*",
  43 │       "logs:List*"
  44 └     ]
  ..
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────



vpc/main.tf (terraform)

Tests: 3 (SUCCESSES: 2, FAILURES: 1, EXCEPTIONS: 0)
Failures: 1 (MEDIUM: 1, HIGH: 0, CRITICAL: 0)

MEDIUM: VPC Flow Logs is not enabled for VPC
═════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════════
VPC Flow Logs provide visibility into network traffic that traverses the VPC and can be used to detect anomalous traffic or insight during security workflows.

See https://avd.aquasec.com/misconfig/avd-aws-0178
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 vpc/main.tf:17-25
   via main.tf:11-52 (module.vpc)
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  17 ┌ resource "aws_vpc" "this" {
  18 │   cidr_block           = var.vpc_cidr
  19 │   enable_dns_hostnames = var.enable_dns_hostnames
  20 │   enable_dns_support   = var.enable_dns_support
  21 │
  22 │   tags = {
  23 │     Name = local.vpc_name
  24 │   }
  25 └ }
─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

```